### PR TITLE
Windows compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/node_modules/

--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 'use strict'
-const { spawnSync, execSync } = require('child_process')
-const untildify = require('untildify')
+const { spawnSync } = require('child_process')
 const path = require('path')
 const fs = require('fs')
 const os = require('os')

--- a/index.js
+++ b/index.js
@@ -12,7 +12,8 @@ if (fs.existsSync(dir)) {
   return process.exit(1)
 }
 
-const tmp = fs.mkdtempSync('git-template')
+const prefix = path.join(os.tmpdir(), 'git-template-')
+const tmp = fs.mkdtempSync(prefix)
 
 spawnSync('git', ['init'], {
   cwd: tmp

--- a/index.js
+++ b/index.js
@@ -12,8 +12,7 @@ if (fs.existsSync(dir)) {
   return process.exit(1)
 }
 
-const { stdout } = spawnSync('mktemp', ['-d'])
-const tmp = String(stdout).trim()
+const tmp = fs.mkdtempSync('git-template')
 
 spawnSync('git', ['init'], {
   cwd: tmp

--- a/package-lock.json
+++ b/package-lock.json
@@ -106,11 +106,6 @@
         "glob": "^6.0.1"
       }
     },
-    "untildify": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
-      "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw=="
-    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   "author": "Chris Dickinson <chris@neversaw.us> (http://neversaw.us/)",
   "license": "MIT",
   "dependencies": {
-    "mv": "^2.1.1",
-    "untildify": "^4.0.0"
+    "mv": "^2.1.1"
   }
 }


### PR DESCRIPTION
Since `mktemp` is used, it fails on Windows.  I've switched that to [`fs.mkdtempSync`](https://nodejs.org/api/fs.html#fs_fs_mkdtempsync_prefix_options).  Thanks!